### PR TITLE
Added ability to create an exclusion list

### DIFF
--- a/alas_but_one.py
+++ b/alas_but_one.py
@@ -17,6 +17,8 @@ from collections import Counter
 # of the type. Hence, "there was, alas, but one".
 
 MAX_OCCUR=1
+OUTPUT_FILE='alas_output.txt'
+EXCLUSION_FILE="alas_exclude.txt"
 WORD_REGEX=re.compile("[\w'_\-]+")
 
 directory = 'source'
@@ -33,7 +35,13 @@ for root, dirs, files in os.walk(directory):
                 print(e)
 
 ctr = Counter(word_list)
-for w,v in sorted(ctr.items(), key=lambda pair: pair[1], reverse=True):
-    if (v <= MAX_OCCUR):
-        print("%s [%d]" % (w,v))
-
+if os.path.isfile(EXCLUSION_FILE):
+    exclusion_list = open(EXCLUSION_FILE).read()
+    for w,v in sorted(ctr.items(), key=lambda pair: pair[1], reverse=True):
+        if (v <= MAX_OCCUR):
+            if (not(w in exclusion_list)):
+                print("%s [%d]" % (w,v), file=open(OUTPUT_FILE, 'a'))
+else:
+    for w,v in sorted(ctr.items(), key=lambda pair: pair[1], reverse=True):
+        if (v <= MAX_OCCUR):
+            print("%s [%d]" % (w,v), file=open(OUTPUT_FILE, 'a'))

--- a/alas_but_one.py
+++ b/alas_but_one.py
@@ -39,7 +39,7 @@ if os.path.isfile(EXCLUSION_FILE):
     exclusion_list = open(EXCLUSION_FILE).read()
     for w,v in sorted(ctr.items(), key=lambda pair: pair[1], reverse=True):
         if (v <= MAX_OCCUR):
-            if (not(w in exclusion_list)):
+            if (not((w + " ") in exclusion_list)):
                 print("%s [%d]" % (w,v), file=open(OUTPUT_FILE, 'a'))
 else:
     for w,v in sorted(ctr.items(), key=lambda pair: pair[1], reverse=True):


### PR DESCRIPTION
This is a slight modification that does the following:

* Outputs to a file rather than the standard out

* Allows users to create an exclusion list. If the list exists, the script now checks to see if results are in the exclusion list before appending them to the file. The assumption is each word in the exclusion file has a space after each word (which matches the format of the output file). This was necessary to avoid missing substrings.